### PR TITLE
Function to create brain mask

### DIFF
--- a/createBrainMask.py
+++ b/createBrainMask.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+
+from dipy.segment.mask import median_otsu
+
+
+def createBrainMaskFromb0Data(b0Data):
+    medianRadius = 4
+    numIterations = 4
+    # Call median_otsu and discard first return value
+    mask = median_otsu(b0Data, medianRadius, numIterations)[1]
+    return mask

--- a/createBrainMask.py
+++ b/createBrainMask.py
@@ -1,14 +1,40 @@
 # -*- coding: utf-8 -*-
 
 
+from os.path import join
 import numpy as np
+import nibabel as nib
 from dipy.segment.mask import median_otsu
 
 
-def createBrainMaskFromb0Data(b0Data):
-    medianRadius = 4
-    numIterations = 4
+def createBrainMaskFromb0Data(b0Data, affineMatrix=None, saveDir=None):
+    """Creates a mask of the brain from a b0 volume.
+    The output is written to file if affineMatrix and saveDir are provided.
+
+    Parameters:
+    ----------
+    b0Data : 3D ndarray
+        MRI scan of the head without diffusion weighting
+    affineMatrix : 4x4 array
+        Affine transformation matrix as in Nifti
+    saveDir : string
+        Directory where the created mask will be saved as 'brainMask.nii.gz'.
+
+    Returns:
+    --------
+    mask : 3D ndarray
+        The binary brain mask.
+    """
+
     # Call median_otsu and discard first return value
-    mask = median_otsu(b0Data, medianRadius, numIterations)[1]
+    mask = median_otsu(b0Data)[1]
     mask = np.logical_and(mask == 1, b0Data > 0)
+
+    if affineMatrix is not None and saveDir is not None:
+        try:
+            maskNifti = nib.Nifti1Image(mask.astype(np.float32), affineMatrix)
+            nib.save(maskNifti, join(saveDir, 'brainMask.nii.gz'))
+        except Exception as e:
+            print('Saving of the brain mask \
+                  failed with message {}'.format(e.message))
     return mask

--- a/createBrainMask.py
+++ b/createBrainMask.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
+import numpy as np
 from dipy.segment.mask import median_otsu
 
 
@@ -9,4 +10,5 @@ def createBrainMaskFromb0Data(b0Data):
     numIterations = 4
     # Call median_otsu and discard first return value
     mask = median_otsu(b0Data, medianRadius, numIterations)[1]
+    mask = np.logical_and(mask == 1, b0Data > 0)
     return mask

--- a/test_createBrainMask.py
+++ b/test_createBrainMask.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+
+import unittest
+from os.path import join, expanduser, isdir
+import numpy as np
+from dipy.data.fetcher import fetch_scil_b0, read_siemens_scil_b0
+from createBrainMask import createBrainMaskFromb0Data
+
+
+class TestCreateBrainMask(unittest.TestCase):
+
+    def test_createBrainMaskFromb0Data(self):
+        homeDirectory = expanduser('~')
+        dataDirectory = join(homeDirectory, '.dipy',
+                             'datasets_multi-site_all_companies')
+
+        if not isdir(dataDirectory):
+            fetch_scil_b0()
+
+        b0Img = read_siemens_scil_b0()
+        b0Data = np.squeeze(b0Img.get_data())
+
+        brainMask = createBrainMaskFromb0Data(b0Data)
+        self.assertTrue(np.array_equal(brainMask.shape, b0Data.shape))
+        # Want to test that brainMask is boolean, but couldn't find a built-in
+        # function
+        dataIsTrueOrFalse = np.logical_or(brainMask == 0, brainMask == 1)
+        self.assertTrue(np.array_equal(dataIsTrueOrFalse,
+                                       np.ones(brainMask.shape)))
+        voxelSizes = b0Img.header.get_zooms()[:3]
+        voxelVolumeInCubicCentimeters = 1e-3*np.prod(voxelSizes)
+        brainVolume = voxelVolumeInCubicCentimeters*np.sum(brainMask)
+        self.assertTrue(brainVolume > 500 and brainVolume < 1500)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()

--- a/test_createBrainMask.py
+++ b/test_createBrainMask.py
@@ -2,37 +2,52 @@
 
 
 import unittest
-from os.path import join, expanduser, isdir
+from os import remove
+from os.path import join, expanduser
 import numpy as np
-from dipy.data.fetcher import fetch_scil_b0, read_siemens_scil_b0
+import nibabel as nib
 from createBrainMask import createBrainMaskFromb0Data
 
 
 class TestCreateBrainMask(unittest.TestCase):
+    dataDirectory = None
+    b0Data = np.array([0])
+    affine = np.eye(4)
+
+    def setUp(self):
+        homeDirectory = expanduser('~')
+        self.dataDirectory = join(homeDirectory, '.dipy')
+        self.b0Data = np.reshape(np.arange(3375.0), (15, 15, 15))
+        self.affine = np.array([[1., 0., 0., 1.],
+                                [0., 2., 0., 2.],
+                                [0., 0., 3., 3.],
+                                [0., 0., 0., 1.]])
+
+    def tearDown(self):
+        try:
+            remove(join(self.dataDirectory, 'brainMask.nii.gz'))
+        except OSError:
+            pass
 
     def test_createBrainMaskFromb0Data(self):
-        homeDirectory = expanduser('~')
-        dataDirectory = join(homeDirectory, '.dipy',
-                             'datasets_multi-site_all_companies')
-
-        if not isdir(dataDirectory):
-            fetch_scil_b0()
-
-        b0Img = read_siemens_scil_b0()
-        b0Data = np.squeeze(b0Img.get_data())
-
-        brainMask = createBrainMaskFromb0Data(b0Data)
-        self.assertTrue(np.array_equal(brainMask.shape, b0Data.shape))
+        brainMask = createBrainMaskFromb0Data(self.b0Data)
+        self.assertTrue(np.array_equal(brainMask.shape, self.b0Data.shape))
         # Want to test that brainMask is boolean, but couldn't find a built-in
         # function
         dataIsTrueOrFalse = np.logical_or(brainMask == 0, brainMask == 1)
         self.assertTrue(np.array_equal(dataIsTrueOrFalse,
                                        np.ones(brainMask.shape)))
-        self.assertTrue(np.all(b0Data[brainMask == 1] > 0))
-        voxelSizes = b0Img.header.get_zooms()[:3]
-        voxelVolumeInCubicCentimeters = 1e-3*np.prod(voxelSizes)
-        brainVolume = voxelVolumeInCubicCentimeters*np.sum(brainMask)
-        self.assertTrue(brainVolume > 500 and brainVolume < 1500)
+        self.assertTrue(np.all(self.b0Data[brainMask == 1] > 0))
+
+    def test_saveAndLoadBrainMask(self):
+        brainMask = createBrainMaskFromb0Data(self.b0Data,
+                                              affineMatrix=self.affine,
+                                              saveDir=self.dataDirectory)
+        loadedBrainMaskNifti = nib.load(join(self.dataDirectory,
+                                             'brainMask.nii.gz'))
+        self.assertTrue(np.allclose(brainMask,
+                                    loadedBrainMaskNifti.get_data()))
+        self.assertTrue(np.allclose(loadedBrainMaskNifti.affine, self.affine))
 
 
 def main():

--- a/test_createBrainMask.py
+++ b/test_createBrainMask.py
@@ -28,6 +28,7 @@ class TestCreateBrainMask(unittest.TestCase):
         dataIsTrueOrFalse = np.logical_or(brainMask == 0, brainMask == 1)
         self.assertTrue(np.array_equal(dataIsTrueOrFalse,
                                        np.ones(brainMask.shape)))
+        self.assertTrue(np.all(b0Data[brainMask == 1] > 0))
         voxelSizes = b0Img.header.get_zooms()[:3]
         voxelVolumeInCubicCentimeters = 1e-3*np.prod(voxelSizes)
         brainVolume = voxelVolumeInCubicCentimeters*np.sum(brainMask)


### PR DESCRIPTION
Refers to #8 .

Basically a thin wrapper of dipy.segment.mask.median_otsu. Currently uses default settings, after #9 is resolved we should check if these settings work well for HCP data.